### PR TITLE
fix: command to upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker run --rm outlinewiki/outline:latest yarn sequelize:migrate
 
 If you're running Outline by cloning this repository, run the following command to upgrade:
 ```
-yarn upgrade
+yarn run upgrade
 ```
 
 ## Development


### PR DESCRIPTION
I tested this on the server. Running `yarn upgrade` will result in yarn self updating. To solve this issue we need to run `yarn run upgrade`. 